### PR TITLE
Adding support for Date properties (member variables) from ActionScript 

### DIFF
--- a/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/BaseReference.java
+++ b/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/BaseReference.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Set;
 
 import org.apache.royale.compiler.clients.ExternCConfiguration.ExcludedMember;
+import org.apache.royale.compiler.clients.ExternCConfiguration.ReadOnlyMember;
 
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.JSDocInfo.Marker;
@@ -117,6 +118,11 @@ public abstract class BaseReference
     public ExcludedMember isExcluded()
     {
         return null;
+    }
+    
+    public ReadOnlyMember isReadOnly()
+    {
+    	return null;
     }
 
     public abstract void emit(StringBuilder sb);

--- a/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/FieldReference.java
+++ b/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/FieldReference.java
@@ -20,6 +20,7 @@
 package org.apache.royale.compiler.internal.codegen.typedefs.reference;
 
 import org.apache.royale.compiler.clients.ExternCConfiguration.ExcludedMember;
+import org.apache.royale.compiler.clients.ExternCConfiguration.ReadOnlyMember;
 import org.apache.royale.compiler.internal.codegen.typedefs.utils.FunctionUtils;
 import org.apache.royale.compiler.internal.codegen.typedefs.utils.JSTypeUtils;
 
@@ -105,19 +106,22 @@ public class FieldReference extends MemberReference
             excluded.print(sb);
             return; // XXX (mschmalle) accessors are not treated right, need to exclude get/set
         }
+        
+        ReadOnlyMember readOnly = isReadOnly();
 
         if (!getClassReference().isInterface() && !getComment().isOverride()
-                && !getClassReference().isPropertyInterfaceImplementation(getBaseName()))
+                && !getClassReference().isPropertyInterfaceImplementation(getBaseName())
+                && (null == readOnly))
         {
             emitVar(sb);
         }
         else
         {
-            emitAccessor(sb);
+            emitAccessor(sb, (null != readOnly));
         }
     }
 
-    private void emitAccessor(StringBuilder sb)
+    private void emitAccessor(StringBuilder sb, boolean isReadOnly)
     {
         boolean isInterface = getClassReference().isInterface();
 
@@ -153,17 +157,20 @@ public class FieldReference extends MemberReference
         sb.append(getBody);
         sb.append(";\n");
 
-        // setter
-        sb.append(indent);
-        sb.append(isPublic);
-        sb.append(staticValue);
-        sb.append("function set ");
-        sb.append(getBaseName());
-        sb.append("(value:");
-        sb.append(type);
-        sb.append("):void");
-        sb.append(setBody);
-        sb.append(";\n");
+        if (!isReadOnly)
+        {
+	        // setter
+	        sb.append(indent);
+	        sb.append(isPublic);
+	        sb.append(staticValue);
+	        sb.append("function set ");
+	        sb.append(getBaseName());
+	        sb.append("(value:");
+	        sb.append(type);
+	        sb.append("):void");
+	        sb.append(setBody);
+	        sb.append(";\n");
+        }
     }
 
     private void emitVar(StringBuilder sb)

--- a/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/MemberReference.java
+++ b/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/MemberReference.java
@@ -20,6 +20,7 @@
 package org.apache.royale.compiler.internal.codegen.typedefs.reference;
 
 import org.apache.royale.compiler.clients.ExternCConfiguration.ExcludedMember;
+import org.apache.royale.compiler.clients.ExternCConfiguration.ReadOnlyMember;
 
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.Node;
@@ -46,6 +47,13 @@ public abstract class MemberReference extends BaseReference
     {
         return getClassReference().getModel().isExcludedMember(
                 getClassReference(), this);
+    }
+    
+    @Override
+    public ReadOnlyMember isReadOnly()
+    {
+    	return getClassReference().getModel().isReadOnlyMember(
+    			getClassReference(), this);
     }
 
 }

--- a/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/ReferenceModel.java
+++ b/compiler-externc/src/main/java/org/apache/royale/compiler/internal/codegen/typedefs/reference/ReferenceModel.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.royale.compiler.clients.ExternCConfiguration;
 import org.apache.royale.compiler.clients.ExternCConfiguration.ExcludedMember;
+import org.apache.royale.compiler.clients.ExternCConfiguration.ReadOnlyMember;
 import org.apache.royale.compiler.clients.problems.ProblemQuery;
 import org.apache.royale.compiler.internal.codegen.typedefs.utils.DebugLogUtils;
 
@@ -345,6 +346,11 @@ public class ReferenceModel
     public ExcludedMember isExcludedMember(ClassReference classReference, MemberReference memberReference)
     {
         return getConfiguration().isExcludedMember(classReference, memberReference);
+    }
+    
+    public ReadOnlyMember isReadOnlyMember(ClassReference classReference, MemberReference memberReference)
+    {
+    	return getConfiguration().isReadOnlyMember(classReference, memberReference);
     }
 
     //--------------------------------------------------------------------------

--- a/compiler-externc/src/test/config/externc-config.xml
+++ b/compiler-externc/src/test/config/externc-config.xml
@@ -134,4 +134,10 @@
     <exclude><class>SVGLocatable</class><name>farthestViewportElement</name></exclude>
     <exclude><class>SVGLocatable</class><name>nearestViewportElement</name></exclude>
 
+    <!-- read-only properties where we only emit a 'get' accessor method -->
+    <field-readonly>
+        <class>Date</class>
+        <name>timezoneOffset</name>
+    </field-readonly>
+
 </royale-config>

--- a/compiler-externc/src/test/resources/typedefs/unit_tests/missing.js
+++ b/compiler-externc/src/test/resources/typedefs/unit_tests/missing.js
@@ -219,3 +219,95 @@ uint.MAX_VALUE;
  * @const
  */
 uint.MIN_VALUE;
+
+// additions to the Date prototype to allow AS code to use these properties
+
+/**
+ * @type {number}
+ */
+Date.prototype.date;
+
+/**
+ * @type {number}
+ */
+Date.prototype.dateUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.day;
+
+/**
+ * @type {number}
+ */
+Date.prototype.dayUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.fullYear;
+
+/**
+ * @type {number}
+ */
+Date.prototype.fullYearUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.hours;
+
+/**
+ * @type {number}
+ */
+Date.prototype.hoursUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.milliseconds;
+
+/**
+ * @type {number}
+ */
+Date.prototype.millisecondsUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.minutes;
+
+/**
+ * @type {number}
+ */
+Date.prototype.minutesUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.month;
+
+/**
+ * @type {number}
+ */
+Date.prototype.monthUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.seconds;
+
+/**
+ * @type {number}
+ */
+Date.prototype.secondsUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.time;
+
+/**
+ * @type {number}
+ */
+Date.prototype.timezoneOffset;

--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/BinaryOperatorEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/BinaryOperatorEmitter.java
@@ -516,9 +516,11 @@ public class BinaryOperatorEmitter extends JSSubEmitter implements
     	FULLYEAR("fullYear", "getFullYear"),
     	MONTH("month", "getMonth"),
     	DATE("date", "getDate"),
+    	DAY("day", "getDay"),
     	FULLYEARUTC("fullYearUTC", "getUTCFullYear"),
     	MONTHUTC("monthUTC", "getUTCMonth"),
     	DATEUTC("dateUTC", "getUTCDate"),
+    	DAYUTC("dayUTC", "getUTCDay"),
     	HOURS("hours", "getHours"),
     	MINUTES("minutes", "getMinutes"),
     	SECONDS("seconds", "getSeconds"),
@@ -526,7 +528,8 @@ public class BinaryOperatorEmitter extends JSSubEmitter implements
     	HOURSUTC("hoursUTC", "getUTCHours"),
     	MINUTESUTC("minutesUTC", "getUTCMinutes"),
     	SECONDSUTC("secondsUTC", "getUTCSeconds"),
-    	MILLISECONDSUTC("millisecondsUTC", "getUTCMilliseconds");
+    	MILLISECONDSUTC("millisecondsUTC", "getUTCMilliseconds"),
+    	TIMEZONEOFFSET("timezoneOffset", "getTimezoneOffset");
     	
     	DatePropertiesGetters(String value, String functionName)
     	{
@@ -554,9 +557,11 @@ public class BinaryOperatorEmitter extends JSSubEmitter implements
     	FULLYEAR("fullYear", "setFullYear"),
     	MONTH("month", "setMonth"),
     	DATE("date", "setDate"),
+    	DAY("day", "setDay"),
     	FULLYEARUTC("fullYearUTC", "setUTCFullYear"),
     	MONTHUTC("monthUTC", "setUTCMonth"),
     	DATEUTC("dateUTC", "setUTCDate"),
+    	DAYUTC("day", "setUTCDay"),
     	HOURS("hours", "setHours"),
     	MINUTES("minutes", "setMinutes"),
     	SECONDS("seconds", "setSeconds"),

--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/royale/JSRoyaleEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/royale/JSRoyaleEmitter.java
@@ -69,6 +69,7 @@ import org.apache.royale.compiler.internal.codegen.js.utils.EmitterUtils;
 import org.apache.royale.compiler.internal.codegen.mxml.royale.MXMLRoyaleEmitter;
 import org.apache.royale.compiler.internal.definitions.AccessorDefinition;
 import org.apache.royale.compiler.internal.definitions.FunctionDefinition;
+import org.apache.royale.compiler.internal.definitions.VariableDefinition;
 import org.apache.royale.compiler.internal.embedding.EmbedData;
 import org.apache.royale.compiler.internal.embedding.EmbedMIMEType;
 import org.apache.royale.compiler.internal.projects.CompilerProject;
@@ -1257,6 +1258,8 @@ public class JSRoyaleEmitter extends JSGoogEmitter implements IJSRoyaleEmitter
 			if (leftDef != null && leftDef.getQualifiedName().equals("Date"))
 			{
 				if (rightDef instanceof AccessorDefinition)
+					return true;
+				else if (rightDef instanceof VariableDefinition)
 					return true;
 				else if (rightDef == null && rightNode.getNodeID() == ASTNodeID.IdentifierID)
 				{

--- a/compiler/src/test/java/as/ASDateTests.java
+++ b/compiler/src/test/java/as/ASDateTests.java
@@ -1,0 +1,389 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package as;
+
+import org.junit.Test;
+
+/**
+ * Feature tests for AS Date objects
+ */
+public class ASDateTests extends ASFeatureTestsBase
+{
+
+    @Test
+    public void ASDateTests_date()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.date += 1;",
+            "assertEqual('date.date', date.date, 1);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_dateUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.dateUTC += 1;",
+            "assertEqual('date.dateUTC', date.dateUTC, 2);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_day()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.day += 1;",
+            "assertEqual('date.day', date.day, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_dayUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.dayUTC += 1;",
+            "assertEqual('date.dayUTC', date.dayUTC, 1);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_fullYear()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Mon Dec 31 23:59:59 GMT-0800 2018');",
+            "date.fullYear += 1;",
+            "assertEqual('date.fullYear', date.fullYear, 2019);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+    
+    @Test
+    public void ASDateTests_fullYearUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Mon Dec 31 23:59:59 GMT-0800 2018');",
+            "date.fullYearUTC += 1;",
+            "assertEqual('date.fullYearUTC', date.fullYearUTC, 2020);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_hours()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.hours += 1;",
+            "assertEqual('date.hours', date.hours, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_hoursUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.hoursUTC += 1;",
+            "assertEqual('date.hoursUTC', date.hoursUTC, 8);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_milliseconds()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.milliseconds -= 1;",
+            "assertEqual('date.milliseconds', date.milliseconds, 999);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_millisecondsUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.millisecondsUTC -= 1;",
+            "assertEqual('date.millisecondsUTC', date.millisecondsUTC, 999);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_minutes()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.minutes += 1;",
+            "assertEqual('date.minutes', date.minutes, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_minutesUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.minutesUTC += 1;",
+            "assertEqual('date.minutesUTC', date.minutesUTC, 1);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_month()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.month += 1;",
+            "assertEqual('date.month', date.month, 6);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_monthUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.monthUTC += 1;",
+            "assertEqual('date.monthUTC', date.monthUTC, 7);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_seconds()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.seconds += 1;",
+            "assertEqual('date.seconds', date.seconds, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_secondsUTC()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.secondsUTC += 1;",
+            "assertEqual('date.secondsUTC', date.secondsUTC, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_time()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.time += 1;",
+            "assertEqual('date.time', date.time, 1530431999001);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+
+    @Test
+    public void ASDateTests_timezoneOffset_get()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "assertEqual('date.timezoneOffset', date.timezoneOffset, -480);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndRun(source);
+    }
+    
+    @Test
+    public void ASDateTests_timezoneOffset_set()
+    {
+        String[] imports = new String[]
+        {
+        };
+        String[] declarations = new String[]
+        {
+        };
+        String[] testCode = new String[]
+        {
+            "var date : Date = new Date('Sat Jun 30 23:59:59 GMT-0800 2018');",
+            "date.timezoneOffset += 480;",
+            "assertEqual('date.timezoneOffset', date.timezoneOffset, 0);",
+        };
+        String source = getAS(imports, declarations, testCode, new String[0]);
+        compileAndExpectErrors(source, false, false, false, null, "Property timezoneOffset is read-only.\n");
+    }
+}

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_dateUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_dateUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/%0.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=834 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}.${build" build="number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0
+    //  method_info  3
+    //  max_stack    1
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  6
+    bb0
+      succs=[]
+      0      getlocal0
+      1      pushscope
+      2      getlocal0
+      3      constructsuper    0
+      4      returnvoid
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler
+    //  method_info  1
+    //  max_stack    4
+    //  max_regs     3
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  35
+    bb0
+      succs=[]
+      0       getlocal0
+      1       pushscope
+      2       findpropstrict  Date
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"
+      4       constructprop
+      5       coerce          Date
+      6       setlocal2
+      7       getlocal2
+      8       getproperty     dateUTC
+      9       pushbyte                                             1
+      10      add
+      11      getlocal2
+      12      swap
+      13      setproperty     dateUTC
+      14      findpropstrict  assertEqual
+      15      pushstring      "date.dateUTC"
+      16      getlocal2
+      17      getproperty     dateUTC
+      18      pushbyte                                             2
+      19      callpropvoid
+      20      returnvoid
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual
+    //  method_info  2
+    //  max_stack    1
+    //  max_regs     4
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null
+    //  method_info  4
+    //  max_stack    0
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    0
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null
+  //  method_info  0
+  //  max_stack    3
+  //  max_regs     1
+  //  scope_depth  0
+  //  max_scope    2
+  //  code_length  14
+  bb0
+    succs=[]
+    0      getlocal0
+    1      pushscope
+    2      getscopeobject                                  0
+    3      getlex          Object
+    4      dup
+    5      pushscope
+    6      newclass
+    7      popscope
+    8      initproperty    %0
+    9      returnvoid
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_date_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_date_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/%0.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=828 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}.${build" build="number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0
+    //  method_info  3
+    //  max_stack    1
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  6
+    bb0
+      succs=[]
+      0      getlocal0
+      1      pushscope
+      2      getlocal0
+      3      constructsuper    0
+      4      returnvoid
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler
+    //  method_info  1
+    //  max_stack    4
+    //  max_regs     3
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  35
+    bb0
+      succs=[]
+      0       getlocal0
+      1       pushscope
+      2       findpropstrict  Date
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"
+      4       constructprop
+      5       coerce          Date
+      6       setlocal2
+      7       getlocal2
+      8       getproperty     date
+      9       pushbyte                                             1
+      10      add
+      11      getlocal2
+      12      swap
+      13      setproperty     date
+      14      findpropstrict  assertEqual
+      15      pushstring      "date.date"
+      16      getlocal2
+      17      getproperty     date
+      18      pushbyte                                             1
+      19      callpropvoid
+      20      returnvoid
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual
+    //  method_info  2
+    //  max_stack    1
+    //  max_regs     4
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null
+    //  method_info  4
+    //  max_stack    0
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    0
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null
+  //  method_info  0
+  //  max_stack    3
+  //  max_regs     1
+  //  scope_depth  0
+  //  max_scope    2
+  //  code_length  14
+  bb0
+    succs=[]
+    0      getlocal0
+    1      pushscope
+    2      getscopeobject                                  0
+    3      getlex          Object
+    4      dup
+    5      pushscope
+    6      newclass
+    7      popscope
+    8      initproperty    %0
+    9      returnvoid
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_dayUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_dayUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests8224847481883983525.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=832 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     dayUTC                                  
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     dayUTC                                  
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.dayUTC"                           
+      16      getlocal2                                               
+      17      getproperty     dayUTC                                  
+      18      pushbyte                                             1  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_day_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_day_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests7093379186885950364.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=826 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     day                                     
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     day                                     
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.day"                              
+      16      getlocal2                                               
+      17      getproperty     day                                     
+      18      pushbyte                                             0  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_fullYearUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_fullYearUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests496304591525783341.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=841 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                              
+    //  max_stack    1                              
+    //  max_regs     1                              
+    //  scope_depth  0                              
+    //  max_scope    1                              
+    //  code_length  6                              
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  36           
+    bb0
+      succs=[]
+      0       getlocal0                                                  
+      1       pushscope                                                  
+      2       findpropstrict  Date                                       
+      3       pushstring      "Mon Dec 31 23:59:59 GMT-0800 2018"        
+      4       constructprop                                              
+      5       coerce          Date                                       
+      6       setlocal2                                                  
+      7       getlocal2                                                  
+      8       getproperty     fullYearUTC                                
+      9       pushbyte                                             1     
+      10      add                                                        
+      11      getlocal2                                                  
+      12      swap                                                       
+      13      setproperty     fullYearUTC                                
+      14      findpropstrict  assertEqual                                
+      15      pushstring      "date.fullYearUTC"                         
+      16      getlocal2                                                  
+      17      getproperty     fullYearUTC                                
+      18      pushshort                                            2020  
+      19      callpropvoid                                               
+      20      returnvoid                                                 
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                         
+    1      pushscope                                         
+    2      getscopeobject                                 0  
+    3      getlex          Object                            
+    4      dup                                               
+    5      pushscope                                         
+    6      newclass                                          
+    7      popscope                                          
+    8      initproperty    %0     
+    9      returnvoid                                        
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_fullYear_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_fullYear_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/%0.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=837 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}.${build" build="number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0
+    //  method_info  3
+    //  max_stack    1
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  6
+    bb0
+      succs=[]
+      0      getlocal0
+      1      pushscope
+      2      getlocal0
+      3      constructsuper    0
+      4      returnvoid
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler
+    //  method_info  1
+    //  max_stack    4
+    //  max_regs     3
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  36
+    bb0
+      succs=[]
+      0       getlocal0
+      1       pushscope
+      2       findpropstrict  Date
+      3       pushstring      "Mon Dec 31 23:59:59 GMT-0800 2018"
+      4       constructprop
+      5       coerce          Date
+      6       setlocal2
+      7       getlocal2
+      8       getproperty     fullYear
+      9       pushbyte                                             1
+      10      add
+      11      getlocal2
+      12      swap
+      13      setproperty     fullYear
+      14      findpropstrict  assertEqual
+      15      pushstring      "date.fullYear"
+      16      getlocal2
+      17      getproperty     fullYear
+      18      pushshort                                            2019
+      19      callpropvoid
+      20      returnvoid
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual
+    //  method_info  2
+    //  max_stack    1
+    //  max_regs     4
+    //  scope_depth  0
+    //  max_scope    1
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null
+    //  method_info  4
+    //  max_stack    0
+    //  max_regs     1
+    //  scope_depth  0
+    //  max_scope    0
+    //  code_length  1
+    bb0
+      succs=[]
+      0      returnvoid
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null
+  //  method_info  0
+  //  max_stack    3
+  //  max_regs     1
+  //  scope_depth  0
+  //  max_scope    2
+  //  code_length  14
+  bb0
+    succs=[]
+    0      getlocal0
+    1      pushscope
+    2      getscopeobject                                  0
+    3      getlex          Object
+    4      dup
+    5      pushscope
+    6      newclass
+    7      popscope
+    8      initproperty    %0
+    9      returnvoid
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_hoursUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_hoursUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests4582668311951197930.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=836 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     hoursUTC                                
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     hoursUTC                                
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.hoursUTC"                         
+      16      getlocal2                                               
+      17      getproperty     hoursUTC                                
+      18      pushbyte                                             8  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_hours_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_hours_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests7909619773103326674.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=830 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     hours                                   
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     hours                                   
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.hours"                            
+      16      getlocal2                                               
+      17      getproperty     hours                                   
+      18      pushbyte                                             0  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_millisecondsUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_millisecondsUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests3159056501171661713.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=851 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  36           
+    bb0
+      succs=[]
+      0       getlocal0                                                 
+      1       pushscope                                                 
+      2       findpropstrict  Date                                      
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"       
+      4       constructprop                                             
+      5       coerce          Date                                      
+      6       setlocal2                                                 
+      7       getlocal2                                                 
+      8       getproperty     millisecondsUTC                           
+      9       pushbyte                                             1    
+      10      subtract                                                  
+      11      getlocal2                                                 
+      12      swap                                                      
+      13      setproperty     millisecondsUTC                           
+      14      findpropstrict  assertEqual                               
+      15      pushstring      "date.millisecondsUTC"                    
+      16      getlocal2                                                 
+      17      getproperty     millisecondsUTC                           
+      18      pushshort                                            999  
+      19      callpropvoid                                              
+      20      returnvoid                                                
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_milliseconds_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_milliseconds_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests8509891553433215777.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=845 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  36           
+    bb0
+      succs=[]
+      0       getlocal0                                                 
+      1       pushscope                                                 
+      2       findpropstrict  Date                                      
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"       
+      4       constructprop                                             
+      5       coerce          Date                                      
+      6       setlocal2                                                 
+      7       getlocal2                                                 
+      8       getproperty     milliseconds                              
+      9       pushbyte                                             1    
+      10      subtract                                                  
+      11      getlocal2                                                 
+      12      swap                                                      
+      13      setproperty     milliseconds                              
+      14      findpropstrict  assertEqual                               
+      15      pushstring      "date.milliseconds"                       
+      16      getlocal2                                                 
+      17      getproperty     milliseconds                              
+      18      pushshort                                            999  
+      19      callpropvoid                                              
+      20      returnvoid                                                
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_minutesUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_minutesUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests1914641614797416572.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=840 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     minutesUTC                              
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     minutesUTC                              
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.minutesUTC"                       
+      16      getlocal2                                               
+      17      getproperty     minutesUTC                              
+      18      pushbyte                                             1  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_minutes_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_minutes_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests9039162940843796750.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=834 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     minutes                                 
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     minutes                                 
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.minutes"                          
+      16      getlocal2                                               
+      17      getproperty     minutes                                 
+      18      pushbyte                                             0  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_monthUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_monthUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests4263460883476555883.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=836 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     monthUTC                                
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     monthUTC                                
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.monthUTC"                         
+      16      getlocal2                                               
+      17      getproperty     monthUTC                                
+      18      pushbyte                                             7  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_month_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_month_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests5050292435478537197.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=830 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     month                                   
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     month                                   
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.month"                            
+      16      getlocal2                                               
+      17      getproperty     month                                   
+      18      pushbyte                                             6  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_secondsUTC_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_secondsUTC_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests8789500309518206008.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=840 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     secondsUTC                              
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     secondsUTC                              
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.secondsUTC"                       
+      16      getlocal2                                               
+      17      getproperty     secondsUTC                              
+      18      pushbyte                                             0  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_seconds_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_seconds_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests1273857251658499900.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=834 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     seconds                                 
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     seconds                                 
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.seconds"                          
+      16      getlocal2                                               
+      17      getproperty     seconds                                 
+      18      pushbyte                                             0  
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_time_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_time_swfdump.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests8684648950939492427.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=836 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  35           
+    bb0
+      succs=[]
+      0       getlocal0                                               
+      1       pushscope                                               
+      2       findpropstrict  Date                                    
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"     
+      4       constructprop                                           
+      5       coerce          Date                                    
+      6       setlocal2                                               
+      7       getlocal2                                               
+      8       getproperty     time                                    
+      9       pushbyte                                             1  
+      10      add                                                     
+      11      getlocal2                                               
+      12      swap                                                    
+      13      setproperty     time                                    
+      14      findpropstrict  assertEqual                             
+      15      pushstring      "date.time"                             
+      16      getlocal2                                               
+      17      getproperty     time                                    
+      18      pushdouble                                              
+      19      callpropvoid                                            
+      20      returnvoid                                              
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>

--- a/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_timezoneOffset_get_swfdump.xml
+++ b/compiler/src/test/resources/swfdumps/as_ASDateTests_ASDateTests_timezoneOffset_get_swfdump.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<!-- Parsing swf file:/C:/Work/Royale/royale-compiler/compiler/target/junit-temp/ASDateTests7609805229404991102.swf -->
+<swf xmlns="http://macromedia/2003/swfx" version="14" framerate="24.0" size="10000x7500" compressed="true" >
+  <!-- framecount=1 length=842 -->
+  <FileAttributes useDirectBlit="false" useGPU="false" hasMetadata="true" actionScript3="true" suppressCrossDomainCaching="false" swfRelativeUrls="false" useNetwork="true"/>
+  <Metadata>
+        <![CDATA[<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1" xmlns:asc="http://ns.adobe.com/asc/2012">
+        <dc:format>application/x-shockwave-flash</dc:format>
+        <asc:compiler name="Apache Royale Compiler" version="${release.version}" build="${build.number}"/>
+    </rdf:Description>
+</rdf:RDF>
+]]>
+  </Metadata>
+  <SetBackgroundColor color="#FFFFFF"/>
+  <ScriptLimits scriptRecursionLimit="1000" scriptTimeLimit="60"/>
+  <DoABC>
+// script 0
+
+// class_id=0 slot_id=0
+public class %0 extends Object
+{
+
+  // method_id=3
+  public function %0():*
+  {
+    //  derivedName  %0  
+    //  method_info  3                               
+    //  max_stack    1                               
+    //  max_regs     1                               
+    //  scope_depth  0                               
+    //  max_scope    1                               
+    //  code_length  6                               
+    bb0
+      succs=[]
+      0      getlocal0            
+      1      pushscope            
+      2      getlocal0            
+      3      constructsuper    0  
+      4      returnvoid           
+  }
+
+  private function initHandler(Object):void
+  {
+    //  derivedName  initHandler  
+    //  method_info  1            
+    //  max_stack    4            
+    //  max_regs     3            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  29           
+    bb0
+      succs=[]
+      0       getlocal0                                                  
+      1       pushscope                                                  
+      2       findpropstrict  Date                                       
+      3       pushstring      "Sat Jun 30 23:59:59 GMT-0800 2018"        
+      4       constructprop                                              
+      5       coerce          Date                                       
+      6       setlocal2                                                  
+      7       findpropstrict  assertEqual                                
+      8       pushstring      "date.timezoneOffset"                      
+      9       getlocal2                                                  
+      10      getproperty     timezoneOffset                             
+      11      pushshort                                            -480  
+      12      callpropvoid                                               
+      13      returnvoid                                                 
+  }
+
+  private function assertEqual(String,*,*):void
+  {
+    //  derivedName  assertEqual  
+    //  method_info  2            
+    //  max_stack    1            
+    //  max_regs     4            
+    //  scope_depth  0            
+    //  max_scope    1            
+    //  code_length  1            
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+
+  public static function %0$():*
+  {
+    //  derivedName  null  
+    //  method_info  4     
+    //  max_stack    0     
+    //  max_regs     1     
+    //  scope_depth  0     
+    //  max_scope    0     
+    //  code_length  1     
+    bb0
+      succs=[]
+      0      returnvoid      
+  }
+}
+
+function script0$init():*
+{
+  //  derivedName  null  
+  //  method_info  0     
+  //  max_stack    3     
+  //  max_regs     1     
+  //  scope_depth  0     
+  //  max_scope    2     
+  //  code_length  14    
+  bb0
+    succs=[]
+    0      getlocal0                                          
+    1      pushscope                                          
+    2      getscopeobject                                  0  
+    3      getlex          Object                             
+    4      dup                                                
+    5      pushscope                                          
+    6      newclass                                           
+    7      popscope                                           
+    8      initproperty    %0     
+    9      returnvoid                                         
+}
+
+  </DoABC>
+  <SymbolClass>
+    <Symbol idref="0" className="%0" />
+  </SymbolClass>
+  <ShowFrame/>
+</swf>


### PR DESCRIPTION
Alongside the changes to the typedefs "missing.js" file, this will ensure that the Royale compiler will correctly identify and allow the Date properties during the parsing/compilation process and will convert these into the appropriate JavaScript getNNN/setNNN methods. Also adding unit tests to check these plus support for a "read-only" configuration setting used to ensure properites such as timezoneOffset result in a getter but not a setter method.