### PR TITLE
closure-compiler: apply run-options during parse

### DIFF
--- a/compiler-jx/src/main/java/org/apache/royale/compiler/utils/JSClosureCompilerWrapper.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/utils/JSClosureCompilerWrapper.java
@@ -50,7 +50,7 @@ import com.google.javascript.jscomp.WarningLevel;
 public class JSClosureCompilerWrapper
 {
 
-    public JSClosureCompilerWrapper(List<String> args)
+    public JSClosureCompilerWrapper(List<String> args) throws IOException
     {
         Compiler.setLoggingLevel(Level.INFO);
 
@@ -490,14 +490,16 @@ public class JSClosureCompilerWrapper
 
     private static class CompilerOptionsParser extends CommandLineRunner
     {
-    	public CompilerOptionsParser(String[] args)
-    	{
-    		super(args);
-    	}
-    	
-    	public CompilerOptions getOptions()
-    	{
-    		return createOptions();
-    	}
+        public CompilerOptionsParser(String[] args)
+        {
+            super(args);
+        }
+        
+        public CompilerOptions getOptions() throws IOException
+        {
+            CompilerOptions options = createOptions();
+            setRunOptions(options);
+            return options;
+        }
     }
 }


### PR DESCRIPTION
CommandLineRunner keeps shared run-options separated and
apply it during compilation

So it was unable to pass some options to closure-compiler using -js-compiler-option (e.g. `--apply_input_source_maps` or `--source_map_location_mapping`)