### PR TITLE
Added a "royale-release" to make the build compatible with the 13 step release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
           <providerImplementations>
             <git>jgit</git>
           </providerImplementations>
-          <arguments combine.self="override">-Papache-release,option-with-swf</arguments>
+          <arguments combine.self="override">-P${release-profiles}</arguments>
         </configuration>
         <dependencies>
           <dependency>
@@ -675,7 +675,6 @@
               <artifactId>maven-release-plugin</artifactId>
               <configuration>
                 <pushChanges>false</pushChanges>
-                <arguments combine.self="override">-Papache-release,apache-release,option-with-swf</arguments>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,8 @@
                   <git>jgit</git>
               </providerImplementations>
               <!-- List of profiles that will be activated in the release:perform phase -->
-              <arguments>-P${release-profiles} ${arguments}</arguments>
+              <releaseProfiles>${release-profiles}</releaseProfiles>
+              <arguments/>
           </configuration>
           <dependencies>
               <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <connection>scm:git:https://github.com/apache/royale-compiler.git</connection>
     <developerConnection>scm:git:https://github.com/apache/royale-compiler.git</developerConnection>
     <url>scm:git:https://github.com/apache/royale-compiler.git</url>
-    <tag>release/0.9.6</tag>
   </scm>
 
   <properties>
@@ -59,6 +58,7 @@
     <option.withSwf.enabled>false</option.withSwf.enabled>
 
     <release-profiles>apache-release,option-with-swf</release-profiles>
+    <deployment-location-override></deployment-location-override>
   </properties>
 
   <!-- Only configure the site distribution as the rest is handled by the apache parent -->
@@ -205,7 +205,7 @@
                   <git>jgit</git>
               </providerImplementations>
               <!-- List of profiles that will be activated in the release:perform phase -->
-              <arguments>-P${release-profiles} ${arguments}</arguments>
+              <arguments>-P${release-profiles} ${arguments} ${deployment-location-override}</arguments>
           </configuration>
           <dependencies>
               <dependency>
@@ -618,7 +618,10 @@
     <profile>
       <id>royale-release</id>
       <properties>
+        <!-- Ensure the royale-release plugin is enabled when running release:perform -->
         <release-profiles>apache-release,royale-release,option-with-swf</release-profiles>
+        <!-- Redirect the deployment to a local directory -->
+        <deployment-location-override>-DaltDeploymentRepository=release-repo::default::file:./local-release-dir</deployment-location-override>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,8 @@
               <providerImplementations>
                   <git>jgit</git>
               </providerImplementations>
-              <arguments>-Papache-release,royale-release ${arguments}</arguments>
+              <!-- List of profiles that will be activated in the release:perform phase -->
+              <arguments>-Papache-release,royale-release,option-with-swf ${arguments}</arguments>
           </configuration>
           <dependencies>
               <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,12 @@
         <repository>
           <id>apache.releases.https</id>
           <name>Apache Release Distribution Repository</name>
+          <!--
+            'maven.multiModuleProjectDirectory' is a property introduced with maven 3.3.1 ...
+            don't worry if your IDE is complaining.
+            Also this will be set to the 'target/checkout' directory the output will be in
+            'target/local-release-dir'.
+          -->
           <url>file://${maven.multiModuleProjectDirectory}/../local-release-dir</url>
         </repository>
       </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,12 @@
               </providerImplementations>
               <!-- List of profiles that will be activated in the release:perform phase -->
               <releaseProfiles>${release-profiles}</releaseProfiles>
-              <arguments/>
+              <!--
+                The apache parent passes the profiles in here,
+                we have to override this with something that doesn't hurt.
+                If left empty, the version from the parent is used.
+              -->
+              <arguments combine.self="override">-DsomePropertyYouCanIgnore=someValueYouCanIgnore</arguments>
           </configuration>
           <dependencies>
               <dependency>
@@ -656,7 +661,10 @@
               <artifactId>maven-deploy-plugin</artifactId>
               <!-- If deploying fails due to repo or network problems, retry the given number of times (1-10) -->
               <configuration>
-                <altReleaseDeploymentRepository>release-repo::default::file:./../local-release-dir</altReleaseDeploymentRepository>
+                <!-- The 'maven.multiModuleProjectDirectory' property is available starting with maven 3.3.1 -->
+                <altReleaseDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altReleaseDeploymentRepository>
+                <altDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altDeploymentRepository>
+                <altSnapshotDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altSnapshotDeploymentRepository>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <option.withSwf.enabled>false</option.withSwf.enabled>
 
     <release-profiles>apache-release,option-with-swf</release-profiles>
-    <deployment-location-override></deployment-location-override>
   </properties>
 
   <!-- Only configure the site distribution as the rest is handled by the apache parent -->
@@ -205,7 +204,7 @@
                   <git>jgit</git>
               </providerImplementations>
               <!-- List of profiles that will be activated in the release:perform phase -->
-              <arguments>-P${release-profiles} ${arguments} ${deployment-location-override}</arguments>
+              <arguments>-P${release-profiles} ${arguments}</arguments>
           </configuration>
           <dependencies>
               <dependency>
@@ -442,6 +441,16 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+          <!-- If deploying fails due to repo or network problems, retry the given number of times (1-10) -->
+          <configuration>
+            <retryFailedDeploymentCount>6</retryFailedDeploymentCount>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.5</version>
@@ -620,8 +629,6 @@
       <properties>
         <!-- Ensure the royale-release plugin is enabled when running release:perform -->
         <release-profiles>apache-release,royale-release,option-with-swf</release-profiles>
-        <!-- Redirect the deployment to a local directory -->
-        <deployment-location-override>-DaltDeploymentRepository=release-repo::default::file:./local-release-dir</deployment-location-override>
       </properties>
       <build>
         <pluginManagement>
@@ -640,6 +647,15 @@
               <artifactId>maven-release-plugin</artifactId>
               <configuration>
                 <pushChanges>false</pushChanges>
+              </configuration>
+            </plugin>
+            <!-- Redirect the deployment to a local directory -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <!-- If deploying fails due to repo or network problems, retry the given number of times (1-10) -->
+              <configuration>
+                <altReleaseDeploymentRepository>release-repo::default::file:./../local-release-dir</altReleaseDeploymentRepository>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -636,6 +636,17 @@
         <!-- Ensure the royale-release plugin is enabled when running release:perform -->
         <release-profiles>apache-release,royale-release,option-with-swf</release-profiles>
       </properties>
+
+      <!-- Redirect the deployment to a local directory -->
+      <!-- Note: using the 'altReleaseDeploymentRepository' and alike were ignored in the release:perform phase -->
+      <distributionManagement>
+        <repository>
+          <id>apache.releases.https</id>
+          <name>Apache Release Distribution Repository</name>
+          <url>file://${maven.multiModuleProjectDirectory}/../local-release-dir</url>
+        </repository>
+      </distributionManagement>
+
       <build>
         <pluginManagement>
           <plugins>
@@ -653,18 +664,6 @@
               <artifactId>maven-release-plugin</artifactId>
               <configuration>
                 <pushChanges>false</pushChanges>
-              </configuration>
-            </plugin>
-            <!-- Redirect the deployment to a local directory -->
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-deploy-plugin</artifactId>
-              <!-- If deploying fails due to repo or network problems, retry the given number of times (1-10) -->
-              <configuration>
-                <!-- The 'maven.multiModuleProjectDirectory' property is available starting with maven 3.3.1 -->
-                <altReleaseDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altReleaseDeploymentRepository>
-                <altDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altDeploymentRepository>
-                <altSnapshotDeploymentRepository>release-repo::default::file:${maven.multiModuleProjectDirectory}/../local-release-dir</altSnapshotDeploymentRepository>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,6 @@
     <flash.version>20.0</flash.version>
     <air.version>20.0</air.version>
     <option.withSwf.enabled>false</option.withSwf.enabled>
-
-    <skipgpg>false</skipgpg>
   </properties>
 
   <!-- Only configure the site distribution as the rest is handled by the apache parent -->
@@ -204,17 +202,18 @@
               <providerImplementations>
                   <git>jgit</git>
               </providerImplementations>
+              <arguments>-Papache-release,royale-release ${arguments}</arguments>
           </configuration>
           <dependencies>
               <dependency>
                   <groupId>org.apache.maven.scm</groupId>
                   <artifactId>maven-scm-provider-jgit</artifactId>
-                  <version>1.11.2-SNAPSHOT</version>
+                  <version>1.11.2</version>
               </dependency>
               <dependency>
                   <groupId>org.apache.maven.scm</groupId>
                   <artifactId>maven-scm-api</artifactId>
-                  <version>1.11.2-SNAPSHOT</version>
+                  <version>1.11.2</version>
               </dependency>
           </dependencies>
       </plugin>
@@ -279,7 +278,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${surefireArgLine}</argLine>
+          <!-- the @-sign implies late-evaluation of the property -->
+          <argLine>@{surefireArgLine}</argLine>
           <systemPropertyVariables>
             <buildType>Maven</buildType>
             <flexVersion>${flex.version}</flexVersion>
@@ -312,7 +312,8 @@
           </execution>
         </executions>
         <configuration>
-          <argLine>${failsafeArgLine}</argLine>
+          <!-- the @-sign implies late-evaluation of the property -->
+          <argLine>@{failsafeArgLine}</argLine>
           <systemPropertyVariables>
             <buildType>Maven</buildType>
             <flexVersion>${flex.version}</flexVersion>
@@ -607,6 +608,36 @@
       </properties>
     </profile>
 
+    <!--
+      This profile enables the changes required to do releases on the Royale CI server.
+      It should not be used otherwise.
+    -->
+    <profile>
+      <id>royale-release</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- We require the release manager to manually login an sign using his credentials -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+            <!-- We require the release manager to login and push the changes using his credentials -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <pushChanges>false</pushChanges>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
     <!-- Make the release-plugin use the new reproducible build plugin extension -->
     <profile>
       <id>apache-release</id>
@@ -622,7 +653,6 @@
             <configuration>
               <preparationGoals>clean com.theoryinpractise:reproducible-maven-plugin:apply install</preparationGoals>
               <completionGoals>com.theoryinpractise:reproducible-maven-plugin:clear</completionGoals>
-              <goals>deploy</goals>
             </configuration>
           </plugin>
         </plugins>
@@ -659,7 +689,5 @@
       </build>
     </profile>
   </profiles>
-
-  
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>22</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.royale.compiler</groupId>
@@ -196,34 +196,26 @@
       </plugin>
 
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
-          <configuration>
-              <providerImplementations>
-                  <git>jgit</git>
-              </providerImplementations>
-              <!-- List of profiles that will be activated in the release:perform phase -->
-              <releaseProfiles>${release-profiles}</releaseProfiles>
-              <!--
-                The apache parent passes the profiles in here,
-                we have to override this with something that doesn't hurt.
-                If left empty, the version from the parent is used.
-              -->
-              <arguments combine.self="override">-DsomePropertyYouCanIgnore=someValueYouCanIgnore</arguments>
-          </configuration>
-          <dependencies>
-              <dependency>
-                  <groupId>org.apache.maven.scm</groupId>
-                  <artifactId>maven-scm-provider-jgit</artifactId>
-                  <version>1.11.2</version>
-              </dependency>
-              <dependency>
-                  <groupId>org.apache.maven.scm</groupId>
-                  <artifactId>maven-scm-api</artifactId>
-                  <version>1.11.2</version>
-              </dependency>
-          </dependencies>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <providerImplementations>
+            <git>jgit</git>
+          </providerImplementations>
+          <arguments combine.self="override">-Papache-release,option-with-swf</arguments>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-jgit</artifactId>
+            <version>1.11.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-api</artifactId>
+            <version>1.11.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>
@@ -547,9 +539,9 @@
         </plugin>
 
         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-scm-plugin</artifactId>
-            <version>1.10.0</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>1.10.0</version>
         </plugin>
 
         <plugin>
@@ -567,7 +559,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0-M1</version>
         </plugin>
 
         <plugin>
@@ -648,6 +640,25 @@
       </distributionManagement>
 
       <build>
+        <plugins>
+          <!-- Generate the effective poms for this build -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-help-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-effective-pom</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>effective-pom</goal>
+                </goals>
+                <configuration>
+                  <output>${project.build.directory}/effective.pom</output>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
         <pluginManagement>
           <plugins>
             <!-- We require the release manager to manually login an sign using his credentials -->
@@ -664,6 +675,7 @@
               <artifactId>maven-release-plugin</artifactId>
               <configuration>
                 <pushChanges>false</pushChanges>
+                <arguments combine.self="override">-Papache-release,apache-release,option-with-swf</arguments>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <flash.version>20.0</flash.version>
     <air.version>20.0</air.version>
     <option.withSwf.enabled>false</option.withSwf.enabled>
+
+    <release-profiles>apache-release,option-with-swf</release-profiles>
   </properties>
 
   <!-- Only configure the site distribution as the rest is handled by the apache parent -->
@@ -203,7 +205,7 @@
                   <git>jgit</git>
               </providerImplementations>
               <!-- List of profiles that will be activated in the release:perform phase -->
-              <arguments>-Papache-release,royale-release,option-with-swf ${arguments}</arguments>
+              <arguments>-P${release-profiles} ${arguments}</arguments>
           </configuration>
           <dependencies>
               <dependency>
@@ -615,6 +617,9 @@
     -->
     <profile>
       <id>royale-release</id>
+      <properties>
+        <release-profiles>apache-release,royale-release,option-with-swf</release-profiles>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -705,6 +705,34 @@
               <completionGoals>com.theoryinpractise:reproducible-maven-plugin:clear</completionGoals>
             </configuration>
           </plugin>
+          <!--
+            Create MD5 and SHA512 checksum files for the release artifacts.
+          -->
+          <plugin>
+            <groupId>net.nicoulaj.maven.plugins</groupId>
+            <artifactId>checksum-maven-plugin</artifactId>
+            <version>1.8</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>files</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <algorithms>
+                <algorithm>SHA-512</algorithm>
+              </algorithms>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                    <include>royale-compiler-parent-${project.version}-source-release.zip</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
I tweaked the settings quite a bit and added a new profile "royale-release" which skips the signing of artifacts, prevents the release-plugin from pushing and redirects the deployment of artifacts to a local directory.

Also did I adjust the configuration of the deploy plugin to retry deployment if this fails (default is no retry, I now set it to 6 retries) In theory this should allow cutting and deploying releases using the flakiest of internet connections.