### PR TITLE
- Removed the line-separator setting as this causes the Antlr3 plugin…

### DIFF
--- a/compiler-common/pom.xml
+++ b/compiler-common/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>org.apache.royale.compiler</groupId>
         <artifactId>royale-compiler-parent</artifactId>
-        <version>0.9.8-SNAPSHOT</version>
+        <version>0.9.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>compiler-common</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
 
     <name>Apache Royale: Compiler: Compiler-Common</name>
     <description>The Apache Royale Compiler Common classes</description>

--- a/compiler-externc/pom.xml
+++ b/compiler-externc/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>compiler-externc</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: Externc</name>
   <description>The Apache Royale Compiler Externs Compiler</description>
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-common</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.javascript</groupId>
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-test-utils</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/compiler-jx/pom.xml
+++ b/compiler-jx/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>compiler-jx</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: Compiler-JX</name>
 
@@ -179,17 +179,17 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-common</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-externc</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -221,7 +221,7 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-test-utils</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-externc</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/compiler-test-utils/pom.xml
+++ b/compiler-test-utils/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>compiler-test-utils</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: Test Utils</name>
   <description>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>compiler</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: Compiler</name>
   <description>The Apache Royale Compiler</description>
@@ -553,7 +553,7 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-common</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.flex</groupId>
@@ -605,13 +605,13 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-test-utils</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-externc</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>debugger</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: Debugger</name>
 
@@ -82,12 +82,12 @@ Do all the JBurg code generation.
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>swfutils</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/flex-compiler-oem/pom.xml
+++ b/flex-compiler-oem/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>flex-compiler-oem</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: OEM Layer</name>
 
@@ -35,17 +35,17 @@
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>compiler-jx</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.royale.compiler</groupId>
       <artifactId>swfutils</artifactId>
-      <version>0.9.8-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.apache.royale.compiler</groupId>
   <artifactId>royale-compiler-parent</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Royale: Compiler: Parent</name>
@@ -200,8 +200,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <!-- Add settings to streamline the line separators on windows and mac/linux -->
-          <arguments combine.self="override">-P${release-profiles} -Dline.separator='\n'</arguments>
+          <arguments combine.self="override">-P${release-profiles}</arguments>
         </configuration>
       </plugin>
 
@@ -324,6 +323,24 @@
             <configuration>
               <failOnWarning>false</failOnWarning>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- This plugin cleans up the jars for anything that might cause problems for reproducible builds -->
+      <!--
+        Even if the core maven plugins currently would support doing this without, we would be required
+        to set the line-separator and the Antlr3 plugin crashes if this is set to something non-default
+      -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -454,6 +471,12 @@
               </manifest>
             </archive>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-archiver-plugin</artifactId>
+          <version>3.0.1</version>
         </plugin>
 
         <plugin>

--- a/royale-ant-tasks/pom.xml
+++ b/royale-ant-tasks/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>royale-ant-tasks</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Royale Ant Tasks</name>
 

--- a/royale-maven-plugin/pom.xml
+++ b/royale-maven-plugin/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>royale-maven-plugin</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Apache Royale: Royale Maven Plugin</name>

--- a/royaleunit-ant-tasks/pom.xml
+++ b/royaleunit-ant-tasks/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>royaleunit-ant-tasks</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: RoyaleUnit Ant Tasks</name>
 

--- a/swfutils/pom.xml
+++ b/swfutils/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.apache.royale.compiler</groupId>
     <artifactId>royale-compiler-parent</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.9.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>swfutils</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.7-SNAPSHOT</version>
 
   <name>Apache Royale: Compiler: SWFUtils</name>
   <description>The Apache Royale Compiler SWF Utility classes</description>


### PR DESCRIPTION
… to crash the VM

- Added the latest version of the reproducible-build-maven-plugin
- Went back to the last development version to re-try releasing with the new settings in place