### PR TITLE
Fix quoting when getProperty() is added for indexed array syntax ([]) on Proxy using an already-quoted value.

### DIFF
--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/MemberAccessEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/MemberAccessEmitter.java
@@ -265,21 +265,33 @@ public class MemberAccessEmitter extends JSSubEmitter implements
 	        	{
 	        		writeLeftSide(node, leftNode, rightNode);
 	        		if (child)
-	        			write(".getProperty('");
+	        			write(".getProperty(");
 	        		String s = fjs.stringifyNode(rightNode);
 	        		int dot = s.indexOf('.');
 	        		if (dot != -1)
 	        		{
 	        			String name = s.substring(0, dot);
 	        			String afterDot = s.substring(dot);
+	        			write("'");
 	        			write(name);
-	        			write("')");
+	        			write("'");
+	        			write(")");
 	        			write(afterDot);
 	        		}
 	        		else
 	        		{
-	        			write(s);
-	        			write("')");
+	        			if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
+	        			{
+	        				// already quoted
+		        			write(s);
+		        		}
+		        		else
+		        		{
+		        			write("'");
+		        			write(s);
+		        			write("'");
+		        		}
+	        			write(")");
 	        		}
 	        		return;
 	        	}


### PR DESCRIPTION
I don't have the resources to actually test this compiler change, sorry.  But I believe these are the changes needed to fix the main part of issue apache/royale-asjs#996 for indexed array syntax ([]) on Proxy and incorrect quoting.