### PR TITLE
fix dispatcher variable initialization: use the staticEventDispatcher…

### DIFF
--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/BindableEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/BindableEmitter.java
@@ -423,7 +423,7 @@ public class BindableEmitter extends JSSubEmitter implements
                 + "var dispatcher = "
                 + qname
                 + ASEmitterTokens.MEMBER_ACCESS.getToken()
-                + BINDABLE_DISPATCHER_NAME
+                + STATIC_DISPATCHER_GETTER
                 + ASEmitterTokens.SEMICOLON.getToken());
         writeNewline(ASEmitterTokens.INDENT.getToken()
                 + ASEmitterTokens.INDENT.getToken()


### PR DESCRIPTION
DISCLAIMER: I am not familiar with the compiler, so this is a solution which is very much focussed on the wood, not the trees. However it seems to make sense in the context of my project (a large flex port), but it could be that I am missing something that is causing this functionality to behave in a buggy way, which is what I am offering a solution for, and that a simple tweak elsewhere might demonstrate how this is supposed to work in its existing form. It does have the benefit of being a super simple change however.

This fixes an issue where a `[Bindable]` globals class containing static variables never fires `ValueChangeEvent`s because `dispatcher` is always `null`. An excerpt from the globals.js (generated) file WITHOUT the change:

```
/**
 * Compiler generated
 * Static Binding support
 * @private
 * @type {org.apache.royale.events.EventDispatcher}
*/
globals._bindingEventDispatcher;

Object.defineProperties(globals, /** @lends {globals} */ {
/**
 * @export
 * @type {org.apache.royale.events.EventDispatcher}
 */
staticEventDispatcher: {
  get: function() {
  		return globals._bindingEventDispatcher
    	|| (globals._bindingEventDispatcher = new org.apache.royale.events.EventDispatcher());
    }
  },
/**
 * @type {XML}
 */
Policies: {
  get: function() {
    return globals.Policies_;
  },
  
  set: function(value) {
    	var oldValue = globals.Policies_;
    	if (value != oldValue) {
      		globals.Policies_ = value;
      		var dispatcher = globals._bindingEventDispatcher;
      		if (dispatcher) dispatcher.dispatchEvent(org.apache.royale.events.ValueChangeEvent.createUpdateEvent(
      			globals, "Policies", oldValue, value));
      }
    }
  },
...
```

The problem here is that `dispatcher` is set to `globals._bindingEventDispatcher` which is never initialized, so the event is never dispatched. After the fix, the setter function looks like:

```
  set: function(value) {
    	var oldValue = globals.Policies_;
    	if (value != oldValue) {
      		globals.Policies_ = value;
      		var dispatcher = globals.staticEventDispatcher;
      		if (dispatcher) dispatcher.dispatchEvent(org.apache.royale.events.ValueChangeEvent.createUpdateEvent(
      			globals, "Policies", oldValue, value));
      }
    }
  },
```

Now `dispatcher` is initialized using the `staticEventDispatcher` getter function which does a lazy init on the underlying variable, and the events are dispatched.
