### PR TITLE
Fix int.MAX_VALUE

### DIFF
--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/IdentifierEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/js/jx/IdentifierEmitter.java
@@ -160,7 +160,7 @@ public class IdentifierEmitter extends JSSubEmitter implements
             	if (baseName.equals("MAX_VALUE"))
             	{
                     startMapping(parentNode);
-            		write("2147483648");
+            		write("2147483647");
                     endMapping(parentNode);
             		return;
             	}

--- a/compiler-jx/src/test/java/org/apache/royale/compiler/internal/codegen/js/sourcemaps/TestSourceMapGlobalClasses.java
+++ b/compiler-jx/src/test/java/org/apache/royale/compiler/internal/codegen/js/sourcemaps/TestSourceMapGlobalClasses.java
@@ -51,8 +51,8 @@ public class TestSourceMapGlobalClasses extends SourceMapTestBase
     {
         IVariableNode node = getVariable("var a:Number = int.MAX_VALUE");
         asBlockWalker.visitVariable(node);
-        //var /** @type {number} */ a = 2147483648
-        assertMapping(node, 0, 15, 0, 30, 0, 40);    // 2147483648
+        //var /** @type {number} */ a = 2147483647
+        assertMapping(node, 0, 15, 0, 30, 0, 40);    // 2147483647
     }
 
     @Test


### PR DESCRIPTION
Fixing `int.MAX_VALUE` as the range for `int` is `-2147483648 ... 2147483647`, not `-2147483648 ... 2147483648`