### PR TITLE
Use qualified name string keys for binding data instead of class definition

### DIFF
--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/mxml/royale/MXMLRoyaleASDocEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/mxml/royale/MXMLRoyaleASDocEmitter.java
@@ -611,7 +611,7 @@ public class MXMLRoyaleASDocEmitter extends MXMLEmitter implements
 	        setProp.id = overrideID;
 	        instances.add(setProp);
             IRoyaleProject project = (IRoyaleProject)(walker.getProject());
-            BindingDatabase bd = project.getBindingMap().get(classDefinition);
+            BindingDatabase bd = project.getBindingMap().get(classDefinition.getQualifiedName());
 	        Set<BindingInfo> bindingInfo = bd.getBindingInfo();
 	        IMXMLDataBindingNode bindingNode = (IMXMLDataBindingNode)propertyOrStyleNode.getChild(0);
 	        for (BindingInfo bi : bindingInfo)

--- a/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/mxml/royale/MXMLRoyaleEmitter.java
+++ b/compiler-jx/src/main/java/org/apache/royale/compiler/internal/codegen/mxml/royale/MXMLRoyaleEmitter.java
@@ -1593,7 +1593,7 @@ public class MXMLRoyaleEmitter extends MXMLEmitter implements
     protected void emitBindingData(String cname, IClassDefinition cdef)
     {
 		IRoyaleProject project = (IRoyaleProject)(walker.getProject());
-		BindingDatabase bd = project.getBindingMap().get(cdef);
+  BindingDatabase bd = project.getBindingMap().get(cdef.getQualifiedName());
         if (bd == null)
             return;
         if (bd.getBindingInfo().isEmpty())
@@ -2853,7 +2853,7 @@ public class MXMLRoyaleEmitter extends MXMLEmitter implements
 	        setProp.id = overrideID;
 	        instances.add(setProp);
 			IRoyaleProject project = (IRoyaleProject)(walker.getProject());
-			BindingDatabase bd = project.getBindingMap().get(classDefinition);
+   BindingDatabase bd = project.getBindingMap().get(classDefinition.getQualifiedName());
 	        Set<BindingInfo> bindingInfo = bd.getBindingInfo();
 	        IMXMLDataBindingNode bindingNode = (IMXMLDataBindingNode)propertyOrStyleNode.getChild(0);
 	        for (BindingInfo bi : bindingInfo)

--- a/compiler/src/main/java/org/apache/royale/compiler/internal/codegen/databinding/MXMLBindingDirectiveHelper.java
+++ b/compiler/src/main/java/org/apache/royale/compiler/internal/codegen/databinding/MXMLBindingDirectiveHelper.java
@@ -89,7 +89,7 @@ public class MXMLBindingDirectiveHelper
     public MXMLBindingDirectiveHelper(MXMLClassDirectiveProcessor ddp, IABCVisitor emitter)
     {
         host = ddp;
-        ddp.getProject().getBindingMap().put(ddp.getClassDefinition(), bindingDataBase);
+        ddp.getProject().getBindingMap().put(ddp.getClassDefinition().getQualifiedName(), bindingDataBase);
         this.emitter = emitter;
     }
     

--- a/compiler/src/main/java/org/apache/royale/compiler/internal/projects/RoyaleProject.java
+++ b/compiler/src/main/java/org/apache/royale/compiler/internal/projects/RoyaleProject.java
@@ -2177,6 +2177,7 @@ public class RoyaleProject extends ASProject implements IRoyaleProject, ICompile
     {
         super.clean();
         manifestManager = null;
+        bindingMap.clear();
     }
 
     @Override
@@ -2732,12 +2733,12 @@ public class RoyaleProject extends ASProject implements IRoyaleProject, ICompile
     }
 
 
-    private HashMap<IClassDefinition, BindingDatabase> bindingMap = new HashMap<IClassDefinition, BindingDatabase>();
+    private HashMap<String, BindingDatabase> bindingMap = new HashMap<String, BindingDatabase>();
     /**
      * Support for access to BindingData from the class definition as key.
      * @return
      */
-    public HashMap<IClassDefinition, BindingDatabase> getBindingMap(){
+    public HashMap<String, BindingDatabase> getBindingMap(){
         return bindingMap;
     }
 

--- a/compiler/src/main/java/org/apache/royale/compiler/projects/IRoyaleProject.java
+++ b/compiler/src/main/java/org/apache/royale/compiler/projects/IRoyaleProject.java
@@ -250,6 +250,6 @@ public interface IRoyaleProject extends IASProject, IXMLNameResolver, IWriteOnly
      * Support for access to BindingData from the class definition as key.
      * @return
      */
-    HashMap<IClassDefinition, BindingDatabase> getBindingMap();
+    HashMap<String, BindingDatabase> getBindingMap();
 
 }


### PR DESCRIPTION
Related to #182 

@joshtynjala I think this might be another GC/timing-related issue. But perhaps a bit simpler, so hopefully this might be a bit easier for you to at least review. I started seeing it today in a project I am working on, after not having seen it for quite some time. I think it is perhaps sensitive to project size and jvm memory allocation (in combination).

Assumption: This is assumed to be some sort of memory management race condition between Garbage Collection and AST re-parsing
- Converted the `bindingMap` in RoyaleProject to use qualified Name String keys instead of volatile IClassDefinition objects.
- Intended to ensure that data-binding information remains accessible even if the compiler re-parses MXML files and re-creates class definitions during a build.